### PR TITLE
Fix Logical Error in unfix Method for Reversed State in Bitset

### DIFF
--- a/src/class032/Code02_DesignBitsetTest.java
+++ b/src/class032/Code02_DesignBitsetTest.java
@@ -65,8 +65,8 @@ public class Code02_DesignBitsetTest {
 				}
 			} else {
 				if ((set[index] & (1 << bit)) == 0) {
-					ones--;
-					zeros++;
+					ones++;
+					zeros--;
 					set[index] |= (1 << bit);
 				}
 			}


### PR DESCRIPTION
### Description
This PR addresses a logical inconsistency in the unfix method of the Bitset class. Previously, the method did not correctly handle the removal of elements in the reversed state (reverse == true). In the reversed state, a bit value of 0 is supposed to represent the existence of an element, whereas 1 represents its absence. However, the existing implementation was incorrectly updating the zeros and ones counters upon removal of an element.