### PR TITLE
close BufferedReader in f1

### DIFF
--- a/src/class097/Code02_InputLong.java
+++ b/src/class097/Code02_InputLong.java
@@ -26,13 +26,14 @@ public class Code02_InputLong {
 		// long类型的64位全用来表达整数部分
 		// 所以读入是long范围的数，如果用以下的写法
 		// in.nval会先变成double类型，如果再转成long类型，就可能有精度损耗
-		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		StreamTokenizer in = new StreamTokenizer(br);
-		PrintWriter out = new PrintWriter(new OutputStreamWriter(System.out));
-		in.nextToken();
-		long num = (long) in.nval;
-		out.println(num);
-		out.flush();
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+			StreamTokenizer in = new StreamTokenizer(br);
+			PrintWriter out = new PrintWriter(new OutputStreamWriter(System.out));
+			in.nextToken();
+			long num = (long) in.nval;
+			out.println(num);
+			out.flush();
+		}
 	}
 
 	public static void f2() throws IOException {


### PR DESCRIPTION
Kept looking at f1 in src/class097/Code02_InputLong.java and wanted to flag something: The resource opened there can leak if f1 exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.